### PR TITLE
Scoreboards are non persistent through reloads 

### DIFF
--- a/src/main/java/io/github/thatkawaiisam/assemble/Assemble.java
+++ b/src/main/java/io/github/thatkawaiisam/assemble/Assemble.java
@@ -7,6 +7,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import lombok.Getter;
 import lombok.Setter;
 
+import org.bukkit.Bukkit;
 import org.bukkit.event.HandlerList;
 import org.bukkit.plugin.java.JavaPlugin;
 
@@ -47,6 +48,14 @@ public class Assemble {
 
 		//Start Thread
 		this.thread = new AssembleThread(this);
+		Bukkit.getOnlinePlayers().forEach(o -> getBoards().put(o.getUniqueId(), new AssembleBoard(o, this)));
+	}
+
+	public void setdown() {
+		Bukkit.getOnlinePlayers().forEach(o -> {
+			getBoards().remove(o.getUniqueId());
+			o.setScoreboard(Bukkit.getScoreboardManager().getMainScoreboard());
+		});
 	}
 
 	public void cleanup() {

--- a/src/main/java/io/github/thatkawaiisam/assemble/AssembleListener.java
+++ b/src/main/java/io/github/thatkawaiisam/assemble/AssembleListener.java
@@ -45,10 +45,11 @@ public class AssembleListener implements Listener {
 		event.getPlayer().setScoreboard(Bukkit.getScoreboardManager().getMainScoreboard());
 	}
 
-	//TODO see how we can make this better
-//	@EventHandler
-//	public void onPluginDisable(PluginDisableEvent event) {
-//		getAssemble().disable();
-//	}
+	@EventHandler
+	public void onPluginDisable(PluginDisableEvent event) {
+		if (event.getPlugin().getName().equals(assemble.getPlugin().getName())) {
+			assemble.setdown();
+		}
+	}
 
 }


### PR DESCRIPTION
I have made scoreboards persistent through reloads by resetting players scoreboards on disable and adding a check to create new scoreboards in [AssembleThread#tick](https://github.com/ohvalsgod/Assemble/blob/master/src/main/java/io/github/thatkawaiisam/assemble/AssembleThread.java#L45-L52). This is required to be run on the main thread, so at high player count there could be some problems.