### PR TITLE
Update AssembleThread.java

### DIFF
--- a/src/main/java/io/github/thatkawaiisam/assemble/AssembleThread.java
+++ b/src/main/java/io/github/thatkawaiisam/assemble/AssembleThread.java
@@ -70,7 +70,7 @@ public class AssembleThread extends Thread {
                     board.getEntries().forEach(AssembleBoardEntry::remove);
                     board.getEntries().clear();
                 } else {
-                    if (this.assemble.getAdapter().getLines(player).size() > 15) {
+                    if (newLines.size() > 15) {
                         newLines = this.assemble.getAdapter().getLines(player).subList(0, 15);
                     }
 


### PR DESCRIPTION
This fixes an issue that causes the scoreboard to be updated twice within one "tick." Which was breaking my custom format animations.